### PR TITLE
Create CODEOWNERS to complete open source review.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+# You can also use email addresses if you prefer.
+
+# Default reviewers
+*       @qpp-semantic-bits-beneficiary-sample-reporting


### PR DESCRIPTION
Per comments from @mnagelia we ought to have a clear mechanism for code ownership, and the CODEOWNERS file has been recommended in other open-sourcing initiatives. Specifically, during final review, it was asked if possible to specify groups and not individual users assigned to contractor teams as this causes problems during staffing shuffles.